### PR TITLE
Corrected solidity version as it is in the main contract.

### DIFF
--- a/contracts/VRFCoordinatorV2Mock.sol
+++ b/contracts/VRFCoordinatorV2Mock.sol
@@ -1,3 +1,3 @@
 //SPDX-License-Identifier:MIT
-pragma solidity 0.8.8;
+pragma solidity ^0.8.4;
 import "@chainlink/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol";


### PR DESCRIPTION
Solidity version should be same as it is in the main contract in chainlink repo.